### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/main/views.py
+++ b/main/views.py
@@ -19,6 +19,7 @@ from langchain_community.embeddings import OpenAIEmbeddings
 from langchain_community.vectorstores import FAISS
 from langchain_openai import OpenAI
 from PyPDF2 import PdfReader
+import logging
 
 from .models import BlogPost, Chat
 
@@ -114,7 +115,8 @@ def chatbot(request):
         except UnicodeDecodeError:
             return JsonResponse({'error': 'Erreur lors du décodage de la requête.'}, status=400)
         except Exception as e:
-            return JsonResponse({'error': f'Erreur lors de la génération de la réponse: {str(e)}'}, status=500)
+            logging.error("Erreur lors de la génération de la réponse", exc_info=True)
+            return JsonResponse({'error': 'Une erreur interne est survenue.'}, status=500)
 
     # Pour les autres méthodes (GET, etc.)
     return render(request, 'chatbot.html')


### PR DESCRIPTION
Potential fix for [https://github.com/Ndeffoloic/Site-Multi-langues/security/code-scanning/2](https://github.com/Ndeffoloic/Site-Multi-langues/security/code-scanning/2)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by using Python's logging module to log the exception details and returning a generic error message in the JSON response.

1. Import the logging module.
2. Configure the logging settings if not already configured.
3. Replace the line that returns the detailed exception message with a line that logs the exception and returns a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
