### PR TITLE
Update pillow version to 12.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -89,7 +89,7 @@ overrides==7.7.0
 packaging==24.2
 pandocfilters==1.5.1
 parso==0.8.4
-pillow==11.0.0
+pillow==12.1.1
 platformdirs==4.3.6
 prometheus_client==0.21.1
 prompt_toolkit==3.0.48


### PR DESCRIPTION
Beccause of a dependabot alert on a vulnerability related to the previous version