### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/Ndeffoloic/Site-Multi-langues/security/code-scanning/1](https://github.com/Ndeffoloic/Site-Multi-langues/security/code-scanning/1)

In general, this problem is fixed by adding an explicit `permissions` block to the workflow (either at the top level or per job) that grants only the minimal scopes needed. Since this workflow only checks out the repository and runs tests, it only needs read access to repository contents.

The single best way to fix this without changing functionality is to add a top-level `permissions` block after the `on:` section and before `jobs:` that limits the `GITHUB_TOKEN` to `contents: read`. This will apply to all jobs in the workflow, including `build`, and matches CodeQL’s suggested minimal starting point. No other scopes (such as `pull-requests`, `issues`, or `packages`) are required based on the current steps.

Concretely, in `.github/workflows/django.yml`, insert:
```yaml
permissions:
  contents: read
```
between the existing trigger definition (`on:` block ending at line 7) and the `jobs:` key on line 9. No imports or additional methods are necessary because this is a pure YAML configuration change for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
